### PR TITLE
SFT-01: feat[stats]: add models for units and handle stats field

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ build:
 	CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" -o bin/$(APP) ./cmd/sftd
 
 test:
-	go test -race -cover -coverprofile=coverage.out $(PKG)
+	go test ./...
 
 lint:
 	golangci-lint run

--- a/cmd/sft/main.go
+++ b/cmd/sft/main.go
@@ -6,4 +6,5 @@ import (
 
 func main() {
 	fmt.Println("SFT: Simfight-Tactics CLI — MVP-0 placeholder")
+
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/0xm0-v1/simfight-tactics
 
 go 1.24.4
+
+require github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/internal/models/units/UNITS.md
+++ b/internal/models/units/UNITS.md
@@ -1,0 +1,73 @@
+# Units Package
+
+1) **Model** – add the field with a clear JSON tag.
+```go
+// File: simfight-tactics/internal/domain/units/stats.go
+type OffenseStats struct {
+    // ...
+    NewStats float64 `json:"new"`
+}
+```
+2) **Defaults** – set a safe baseline.
+```go
+// File: simfight-tactics/internal/domain/units/stats_defaults.go
+var defaultStats = Stats{
+    Offense: OffenseStats{
+        // ...
+        NewStats: 0, // baseline
+    },
+    // ...
+}
+```
+3) **Sanitize** (data invariants only) – no game logic here.
+```go
+// File: simfight-tactics/internal/domain/units/stats_sanitize.go
+func sanitizeOffense(o OffenseStats) OffenseStats {
+    return OffenseStats{
+        // ...
+        NewStats: maxf(0, o.NewStats), // non-negative
+    }
+}
+```
+4) **Functional Option** – ergonomic setter (+ covered by bulk setters).
+```go
+// File: simfight-tactics/internal/domain/units/stats_options.go
+// Granular setter
+func WithNewStats(v float64) Option {
+    return setOffense(func(o *OffenseStats) { o.NewStats = maxf(0, v) })
+}
+```
+
+### Helper cheat sheet (`stats_sanitize.go`) — compact, human-friendly
+
+**Rule:** enforce **data invariants only** here. **Gameplay caps/conversions live in the engine.**
+
+---
+
+**`anyNaN(vals...) bool` — reject non-finite input**
+- **Use:** upfront guard in options / `normalized()` → `if anyNaN(...) { return err }`
+- **Avoid:** coercion (never “fix” NaN here).
+- **Example:** `if anyNaN(min, max, start, regen) return fmt.Errorf("mana contains NaN")`
+
+**`nonNeg(v) float64` — clamp to ≥ 0 (propagates NaN)**
+- **Use:** AD, AP, AS, HP, Armor, MR, Durability, Omnivamp, Mana*.
+- **Avoid:** fields that may be negative (e.g., `DamageAmp`).
+- **Example:** `o.AD = nonNeg(o.AD)`  // if NaN → stays NaN and will be caught by validation
+
+**`clamp(v, lo, hi) float64` — bound to [lo, hi]**
+- **Use:** structural ranges (e.g., `ManaStart ∈ [ManaMin, ManaMax]`).
+- **Avoid:** gameplay limits (no crit 100% cap, no AS 5/6 cap here).
+- **Example:** `start = clamp(r.ManaStart, min, max)`
+
+**`maxf(a, b) float64` — primitive max (does not handle NaN)**
+- **Use:** compose invariants (`maxf(0, v)`, `maxf(min, max)`).
+- **Avoid:** direct use with potentially NaN inputs; guard with `anyNaN` first.
+- **Example:** `max = maxf(min, r.ManaMax)`  // ensures `max >= min`
+
+---
+
+**One-liners you’ll actually write**
+```go
+o.CritChance = nonNeg(o.CritChance) // no upper clamp here; engine handles overflow
+d.Armor      = nonNeg(d.Armor)
+r.ManaStart  = clamp(r.ManaStart, maxf(0, r.ManaMin), maxf(maxf(0, r.ManaMin), r.ManaMax))

--- a/internal/models/units/models.go
+++ b/internal/models/units/models.go
@@ -1,0 +1,14 @@
+package units
+
+import (
+	"github.com/google/uuid"
+)
+
+type Unit struct {
+	ID     uuid.UUID `json:"id"`
+	Name   string    `json:"name"`
+	Cost   int       `json:"cost"`
+	Traits []string  `json:"traits"`
+	Roles  []string  `json:"roles"`
+	Stats  Stats     `json:"stats"`
+}

--- a/internal/models/units/stats.go
+++ b/internal/models/units/stats.go
@@ -1,0 +1,51 @@
+package units
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Stats groups offensive, defensive, and resource stats.
+type Stats struct {
+	Offense  OffenseStats `json:"offense"`
+	Defense  DefenseStats `json:"defense"`
+	Resource Resource     `json:"resource"`
+}
+
+// OffenseStats represents offensive stats.
+type OffenseStats struct {
+	Range      float64 `json:"range"`
+	BaseAD     float64 `json:"base_attack_damage"`
+	AD         float64 `json:"attack_damage"`
+	AP         float64 `json:"ability_power"`
+	AS         float64 `json:"attack_speed"`
+	CritChance float64 `json:"critical_strike_chance"`
+	CritDamage float64 `json:"critical_strike_damage"`
+	Omnivamp   float64 `json:"omnivamp"`
+	DamageAmp  float64 `json:"damage_amp"`
+}
+
+// DefenseStats represents defensive stats.
+type DefenseStats struct {
+	HP         float64 `json:"hp"`
+	Armor      float64 `json:"armor"`
+	MR         float64 `json:"magic_resist"`
+	Durability float64 `json:"durability"`
+}
+
+// Resource represents resource-related values (e.g., mana).
+type Resource struct {
+	ManaMin   float64 `json:"mana_min"`
+	ManaMax   float64 `json:"mana_max"`
+	ManaStart float64 `json:"mana_start"`
+	ManaRegen float64 `json:"mana_regen"`
+}
+
+func (s Stats) String() string {
+	// Pretty-print via JSON to leverage json tags
+	b, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return fmt.Sprintf("Stats<marshal error: %v>", err)
+	}
+	return string(b)
+}

--- a/internal/models/units/stats_default.go
+++ b/internal/models/units/stats_default.go
@@ -1,0 +1,32 @@
+package units
+
+// defaultStats is unexported to prevent accidental global mutation.
+var defaultStats = Stats{
+	Offense: OffenseStats{
+		Range:      1,
+		BaseAD:     0,
+		AD:         0,
+		AP:         0,
+		AS:         0,
+		CritChance: 0.25,
+		// Baseline crit damage = 140% (1.4)
+		CritDamage: 1.4,
+		DamageAmp:  0,
+		Omnivamp:   0,
+	},
+	Defense: DefenseStats{
+		HP:         0,
+		Armor:      0,
+		MR:         0,
+		Durability: 0,
+	},
+	Resource: Resource{
+		ManaMin:   0,
+		ManaMax:   0,
+		ManaStart: 0,
+		ManaRegen: 0,
+	},
+}
+
+// Default returns a copy of default values.
+func Default() Stats { return defaultStats }

--- a/internal/models/units/stats_options.go
+++ b/internal/models/units/stats_options.go
@@ -1,0 +1,136 @@
+package units
+
+import "fmt"
+
+// Option is the functional option type for Stats.
+type Option func(*Stats) error
+
+// NewStats builds Stats from Default() + options, validates, then sanitizes.
+func NewStats(opts ...Option) (Stats, error) {
+	s := Default()
+	for _, opt := range opts {
+		if err := opt(&s); err != nil {
+			return Stats{}, err
+		}
+	}
+	// Fail-fast validation BEFORE final normalization
+	if err := s.Validate(); err != nil {
+		return Stats{}, err
+	}
+	return s.normalized(), nil
+}
+
+// With applies options on a copy, validates, then sanitizes.
+func (s Stats) With(opts ...Option) (Stats, error) {
+	cp := s
+	for _, opt := range opts {
+		if err := opt(&cp); err != nil {
+			return Stats{}, err
+		}
+	}
+	if err := cp.Validate(); err != nil {
+		return Stats{}, err
+	}
+	return cp.normalized(), nil
+}
+
+// --- Offense (granular setters) ---
+// Set RAW values; sanitization happens in sanitizeOffense via setOffense wrapper.
+func WithRange(v float64) Option  { return setOffense(func(o *OffenseStats) { o.Range = v }) }
+func WithBaseAD(v float64) Option { return setOffense(func(o *OffenseStats) { o.BaseAD = v }) }
+func WithAD(v float64) Option     { return setOffense(func(o *OffenseStats) { o.AD = v }) }
+func WithAP(v float64) Option     { return setOffense(func(o *OffenseStats) { o.AP = v }) }
+func WithAS(v float64) Option     { return setOffense(func(o *OffenseStats) { o.AS = v }) }
+
+// Do NOT clamp to 1 here: >100% crit is converted to crit damage by the engine (2:1 overflow rule).
+func WithCritChance(v float64) Option { return setOffense(func(o *OffenseStats) { o.CritChance = v }) }
+func WithCritDamage(v float64) Option { return setOffense(func(o *OffenseStats) { o.CritDamage = v }) }
+func WithOmnivamp(v float64) Option   { return setOffense(func(o *OffenseStats) { o.Omnivamp = v }) }
+func WithDamageAmp(v float64) Option  { return setOffense(func(o *OffenseStats) { o.DamageAmp = v }) }
+
+// Bulk setter with sanitization.
+func WithOffense(off OffenseStats) Option {
+	return func(s *Stats) error {
+		s.Offense = sanitizeOffense(off)
+		return nil
+	}
+}
+
+// --- Defense ---
+func WithHP(v float64) Option         { return setDefense(func(d *DefenseStats) { d.HP = v }) }
+func WithArmor(v float64) Option      { return setDefense(func(d *DefenseStats) { d.Armor = v }) }
+func WithMR(v float64) Option         { return setDefense(func(d *DefenseStats) { d.MR = v }) }
+func WithDurability(v float64) Option { return setDefense(func(d *DefenseStats) { d.Durability = v }) }
+
+// Bulk setter with sanitization.
+func WithDefense(def DefenseStats) Option {
+	return func(s *Stats) error {
+		s.Defense = sanitizeDefense(def)
+		return nil
+	}
+}
+
+// --- Resource ---
+func WithMana(min, max, start, regen float64) Option {
+	return func(s *Stats) error {
+		// Validation at the boundary (reject non-finite early)
+		if anyNonFinite(min, max, start, regen) {
+			return fmt.Errorf("resource contains non-finite values")
+		}
+		// Sanitation (cross-field invariants)
+		s.Resource = sanitizeResource(Resource{
+			ManaMin:   min,
+			ManaMax:   max,
+			ManaStart: start,
+			ManaRegen: regen,
+		})
+		return nil
+	}
+}
+
+func WithResource(res Resource) Option {
+	return func(s *Stats) error {
+		if anyNonFinite(res.ManaMin, res.ManaMax, res.ManaStart, res.ManaRegen) {
+			return fmt.Errorf("resource contains non-finite values")
+		}
+		s.Resource = sanitizeResource(res)
+		return nil
+	}
+}
+
+// -----------------------------
+// Internals
+// -----------------------------
+
+func setOffense(f func(*OffenseStats)) Option {
+	return func(s *Stats) error {
+		if s == nil {
+			return fmt.Errorf("nil Stats")
+		}
+		tmp := s.Offense
+		f(&tmp)                          // set RAW input
+		s.Offense = sanitizeOffense(tmp) // then sanitize deterministically
+		return nil
+	}
+}
+
+func setDefense(f func(*DefenseStats)) Option {
+	return func(s *Stats) error {
+		if s == nil {
+			return fmt.Errorf("nil Stats")
+		}
+		tmp := s.Defense
+		f(&tmp) // set RAW input
+		s.Defense = sanitizeDefense(tmp)
+		return nil
+	}
+}
+
+// normalized applies final sanitation only (data invariants).
+// All fail-fast validation happens BEFORE calling this.
+func (s Stats) normalized() Stats {
+	s.Offense = sanitizeOffense(s.Offense)
+	s.Defense = sanitizeDefense(s.Defense)
+	s.Resource = sanitizeResource(s.Resource)
+	return s
+}

--- a/internal/models/units/stats_sanitize.go
+++ b/internal/models/units/stats_sanitize.go
@@ -1,0 +1,75 @@
+package units
+
+import "math"
+
+// sanitizeOffense enforces data invariants only.
+// Mechanics (AS cap 5.0/6.0, crit overflow 2:1, anti-heal, etc.) live in the engine.
+func sanitizeOffense(o OffenseStats) OffenseStats {
+	return OffenseStats{
+		Range:  nonNeg(o.Range),
+		BaseAD: nonNeg(o.BaseAD),
+		AD:     nonNeg(o.AD),
+		AP:     nonNeg(o.AP),
+		AS:     nonNeg(o.AS),
+		// Do NOT clamp to [0,1] here: engine converts overflow >100% to crit damage (2:1).
+		CritChance: nonNeg(o.CritChance),
+		CritDamage: maxf(1.0, o.CritDamage),
+		Omnivamp:   nonNeg(o.Omnivamp),
+		DamageAmp:  o.DamageAmp, // may be negative or positive
+	}
+}
+
+func sanitizeDefense(d DefenseStats) DefenseStats {
+	return DefenseStats{
+		HP:         nonNeg(d.HP),
+		Armor:      nonNeg(d.Armor),
+		MR:         nonNeg(d.MR),
+		Durability: nonNeg(d.Durability),
+	}
+}
+
+// sanitizeResource enforces cross-field invariants for Resource.
+func sanitizeResource(r Resource) Resource {
+	min := maxf(0, r.ManaMin)
+	max := maxf(min, r.ManaMax)           // ensure max >= min
+	start := clamp(r.ManaStart, min, max) // ensure start in [min, max]
+	return Resource{
+		ManaMin:   min,
+		ManaMax:   max,
+		ManaStart: start,
+		ManaRegen: maxf(0, r.ManaRegen),
+	}
+}
+
+// -----------------------------
+// Math / guard utilities
+// -----------------------------
+
+// nonNeg clamps negatives to 0, but **does not** coerce NaN/±Inf;
+// non-finites are left as-is so Validate() can fail fast.
+func nonNeg(v float64) float64 {
+	if math.IsNaN(v) || math.IsInf(v, 0) {
+		return v // propagate non-finite to validation
+	}
+	if v < 0 {
+		return 0
+	}
+	return v
+}
+
+func clamp(v, lo, hi float64) float64 {
+	if v < lo {
+		return lo
+	}
+	if v > hi {
+		return hi
+	}
+	return v
+}
+
+func maxf(a, b float64) float64 {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/internal/models/units/stats_sanitize_test.go
+++ b/internal/models/units/stats_sanitize_test.go
@@ -1,0 +1,170 @@
+package units
+
+import (
+	"reflect"
+	"testing"
+)
+
+// build is a test helper that always enforces the champion Range (>=1) so validation passes,
+// then returns sanitized Stats built from the provided options.
+func build(t *testing.T, opts ...Option) Stats {
+	t.Helper()
+	// Put WithRange(1) FIRST so an explicit WithRange(...) in opts can override it.
+	opts = append([]Option{WithRange(1)}, opts...)
+	s, err := NewStats(opts...)
+	if err != nil {
+		t.Fatalf("build failed: %v", err)
+	}
+	return s
+}
+
+func TestSanitize_NonNegatives(t *testing.T) {
+	t.Parallel()
+
+	s := build(t,
+		WithAD(-10),
+		WithAP(-1),
+		WithHP(-5),
+		WithArmor(-2),
+		WithMR(-3),
+		WithDurability(-4),
+		WithOmnivamp(-0.25),
+	)
+
+	if s.Offense.AD != 0 {
+		t.Errorf("AD: want 0, got %v", s.Offense.AD)
+	}
+	if s.Offense.AP != 0 {
+		t.Errorf("AP: want 0, got %v", s.Offense.AP)
+	}
+	if s.Defense.HP != 0 {
+		t.Errorf("HP: want 0, got %v", s.Defense.HP)
+	}
+	if s.Defense.Armor != 0 {
+		t.Errorf("Armor: want 0, got %v", s.Defense.Armor)
+	}
+	if s.Defense.MR != 0 {
+		t.Errorf("MR: want 0, got %v", s.Defense.MR)
+	}
+	if s.Defense.Durability != 0 {
+		t.Errorf("Durability: want 0, got %v", s.Defense.Durability)
+	}
+	if s.Offense.Omnivamp != 0 {
+		t.Errorf("Omnivamp: want 0, got %v", s.Offense.Omnivamp)
+	}
+}
+
+func TestSanitize_CritDamageFloor(t *testing.T) {
+	t.Parallel()
+
+	s := build(t, WithCritDamage(0.5))
+	if s.Offense.CritDamage != 1.0 {
+		t.Errorf("CritDamage: want 1.0 floor, got %v", s.Offense.CritDamage)
+	}
+
+	s2 := build(t, WithCritDamage(1.7))
+	if s2.Offense.CritDamage != 1.7 {
+		t.Errorf("CritDamage: want unchanged 1.7, got %v", s2.Offense.CritDamage)
+	}
+}
+
+func TestSanitize_AttackSpeed(t *testing.T) {
+	t.Parallel()
+
+	t.Run("NegativeClampedToZero", func(t *testing.T) {
+		s := build(t, WithAS(-0.3))
+		if s.Offense.AS != 0 {
+			t.Errorf("AS: want 0 when negative, got %v", s.Offense.AS)
+		}
+	})
+
+	t.Run("NoGameplayCapApplied", func(t *testing.T) {
+		s := build(t, WithAS(7.0))
+		if s.Offense.AS != 7.0 {
+			t.Errorf("AS: should be unchanged (no cap in data layer), got %v", s.Offense.AS)
+		}
+	})
+}
+
+func TestSanitize_ResourceInvariants(t *testing.T) {
+	t.Parallel()
+
+	t.Run("StartAboveMax_ClampedToMax", func(t *testing.T) {
+		s := build(t, WithMana(100, 200, 300, 5)) // start > max
+		if s.Resource.ManaMin != 100 || s.Resource.ManaMax != 200 || s.Resource.ManaStart != 200 || s.Resource.ManaRegen != 5 {
+			t.Errorf("Resource clamp to Max failed: %+v", s.Resource)
+		}
+	})
+
+	t.Run("StartBelowMin_ClampedToMin", func(t *testing.T) {
+		s := build(t, WithMana(50, 120, 25, 3)) // start < min
+		if s.Resource.ManaStart != 50 {
+			t.Errorf("ManaStart clamp to Min failed: got %v", s.Resource.ManaStart)
+		}
+	})
+
+	t.Run("MaxBelowMin_AdjustedUpToMin", func(t *testing.T) {
+		s := build(t, WithMana(80, 30, 80, 1)) // max < min
+		if s.Resource.ManaMax != 80 {
+			t.Errorf("ManaMax bumped to Min failed: got %v", s.Resource.ManaMax)
+		}
+		if s.Resource.ManaStart != 80 {
+			t.Errorf("ManaStart re-clamped to new Max failed: got %v", s.Resource.ManaStart)
+		}
+	})
+
+	t.Run("NegativeMinAndRegen_ClampedToZero", func(t *testing.T) {
+		s := build(t, WithMana(-10, 40, 0, -5))
+		if s.Resource.ManaMin != 0 {
+			t.Errorf("ManaMin: want 0, got %v", s.Resource.ManaMin)
+		}
+		if s.Resource.ManaRegen != 0 {
+			t.Errorf("ManaRegen: want 0, got %v", s.Resource.ManaRegen)
+		}
+	})
+}
+
+func TestSanitize_BulkVsGranular_Offense(t *testing.T) {
+	t.Parallel()
+
+	a := build(t,
+		WithOffense(OffenseStats{
+			Range:      1, // pour passer Validate()
+			AD:         55,
+			Omnivamp:   -0.10,                        // sera clampé à 0
+			CritChance: Default().Offense.CritChance, // 0.25
+			CritDamage: Default().Offense.CritDamage, // 1.4
+		}),
+	)
+	b := build(t,
+		WithAD(55),
+		WithOmnivamp(-0.10),
+	)
+
+	if !reflect.DeepEqual(a.Offense, b.Offense) {
+		t.Errorf("Offense mismatch between bulk and granular.\n bulk=%+v\n gran=%+v", a.Offense, b.Offense)
+	}
+}
+
+func TestSanitize_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	s1 := build(t,
+		WithAD(60),
+		WithAS(0.9),
+		WithArmor(30),
+		WithMana(0, 60, 30, 5),
+		WithCritDamage(1.4),
+		WithOmnivamp(0.1),
+	)
+
+	// Re-run normalization without changes (With() no options).
+	s2, err := s1.With() // applies Validate() + normalized() again
+	if err != nil {
+		t.Fatalf("unexpected error on With(): %v", err)
+	}
+
+	if !reflect.DeepEqual(s1, s2) {
+		t.Errorf("sanitize should be idempotent.\n s1=%+v\n s2=%+v", s1, s2)
+	}
+}

--- a/internal/models/units/stats_validation.go
+++ b/internal/models/units/stats_validation.go
@@ -1,0 +1,36 @@
+package units
+
+import (
+	"fmt"
+	"math"
+)
+
+// anyNonFinite returns true if any value is NaN or ±Inf (fail-fast guard).
+func anyNonFinite(vals ...float64) bool {
+	for _, v := range vals {
+		if math.IsNaN(v) || math.IsInf(v, 0) {
+			return true
+		}
+	}
+	return false
+}
+
+// Validate performs fail-fast checks we do NOT want to auto-correct.
+// It does NOT mutate s. Sanitation (non-negativity, clamping) happens elsewhere.
+func (s Stats) Validate() error {
+	// 1) Non-finite numbers are always invalid.
+	if anyNonFinite(
+		s.Offense.Range, s.Offense.BaseAD, s.Offense.AD, s.Offense.AP, s.Offense.AS,
+		s.Offense.CritChance, s.Offense.CritDamage, s.Offense.Omnivamp, s.Offense.DamageAmp,
+		s.Defense.HP, s.Defense.Armor, s.Defense.MR, s.Defense.Durability,
+		s.Resource.ManaMin, s.Resource.ManaMax, s.Resource.ManaStart, s.Resource.ManaRegen,
+	) {
+		return fmt.Errorf("stats contain non-finite values (NaN/±Inf)")
+	}
+
+	// 2) Champion constraint: must be able to hit adjacent hexes.
+	if s.Offense.Range < 1 {
+		return fmt.Errorf("range must be >= 1")
+	}
+	return nil
+}

--- a/internal/models/units/stats_validation_test.go
+++ b/internal/models/units/stats_validation_test.go
@@ -1,0 +1,91 @@
+package units
+
+import (
+	"math"
+	"strings"
+	"testing"
+)
+
+// Reject non-finite: either caught at option boundary (WithMana) or by Validate() after options.
+func TestValidateRejectsNonFinite(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		opt  Option
+	}{
+		// Offense path → caught by Validate()
+		{"AD_NaN", WithAD(math.NaN())},
+		{"AD_PosInf", WithAD(math.Inf(+1))},
+		{"AD_NegInf", WithAD(math.Inf(-1))},
+
+		// Defense path → caught by Validate()
+		{"Armor_NaN", WithArmor(math.NaN())},
+		{"Armor_PosInf", WithArmor(math.Inf(+1))},
+		{"Armor_NegInf", WithArmor(math.Inf(-1))},
+
+		// Resource path → caught at option boundary (WithMana)
+		{"Mana_NaN", WithMana(math.NaN(), math.NaN(), math.NaN(), math.NaN())},
+		{"Mana_PosInf", WithMana(math.Inf(+1), math.Inf(+1), math.Inf(+1), math.Inf(+1))},
+		{"Mana_NegInf", WithMana(math.Inf(-1), math.Inf(-1), math.Inf(-1), math.Inf(-1))},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := NewStats(tc.opt)
+			if err == nil {
+				t.Fatalf("expected error for non-finite input (%s), got nil", tc.name)
+			}
+			if !strings.Contains(err.Error(), "non-finite") {
+				t.Fatalf("error should mention 'non-finite'; got: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidate_RangeConstraint(t *testing.T) {
+	t.Parallel()
+
+	// Invalid: must be able to hit adjacent hex (range < 1 should fail)
+	_, err := NewStats(WithRange(0.5))
+	if err == nil {
+		t.Fatalf("expected error when range < 1")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "range") {
+		t.Fatalf("error should mention range, got: %v", err)
+	}
+
+	// Valid boundary
+	_, err = NewStats(WithRange(1))
+	if err != nil {
+		t.Fatalf("unexpected error at range == 1: %v", err)
+	}
+
+	// Valid > 1
+	_, err = NewStats(WithRange(3))
+	if err != nil {
+		t.Fatalf("unexpected error at range == 3: %v", err)
+	}
+}
+
+func TestWithResource_RejectsNonFinite(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewStats(
+		WithRange(1),
+		WithResource(Resource{
+			ManaMin:   math.NaN(),
+			ManaMax:   100,
+			ManaStart: 0,
+			ManaRegen: 5,
+		}),
+	)
+	if err == nil {
+		t.Fatalf("expected error for non-finite resource")
+	}
+	if !strings.Contains(err.Error(), "non-finite") {
+		t.Fatalf("error should mention 'non-finite'; got: %v", err)
+	}
+}


### PR DESCRIPTION
# PR Title
SFT-01: feat[stats]: add models for units and handle stats field

## What
Introduce the Stats data model for units (Offense, Defense, Resource) with a functional-options API.
Includes fail-fast validation and deterministic sanitization, plus sensible defaults and a JSON-friendly String().

## Why
Provide a clean, reproducible data layer that enforces invariants before the combat engine consumes the data.

## How
**Key points:**
- Data structures: Stats composed of OffenseStats, DefenseStats, Resource (with JSON tags).
- Functional Options (WithAD, WithArmor, WithMana, etc.) via NewStats/With.
- Validation: reject non-finite values (NaN/±Inf) and enforce Range >= 1.
- Sanitization: non-negative clamps; CritDamage floored to 1.0; resource cross-field invariants (min/max/start/regen).
- Default() provides safe baseline (e.g., CritChance=0.25, CritDamage=1.4).
- Normalization step is idempotent to guarantee determinism.
**Backward compat**
- New feature; no breaking changes expected.
- Invalid inputs (e.g., Range < 1, NaN) now fail explicitly.

## Tests
 - Reject non-finite inputs (Offense/Defense via Validate, Resource via WithMana)
 - Range constraint (range < 1 fails; 1 and >1 pass)
 - Clamp negatives (AD/AP/HP/Armor/MR/Durability/Omnivamp)
 - CritDamage floor at 1.0
 - Attack Speed: negatives clamped to 0; no gameplay cap at data layer
 - Resource invariants (Min/Max/Start clamping; Min & Regen ≥ 0)
 - Bulk vs granular equivalence (Offense)
 - Idempotency (re-normalization is a no-op)
 - WithResource rejects non-finite (its own guard)
- Deterministic, parallel tests; no RNG

